### PR TITLE
Support for error message customization

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,10 +181,26 @@ const delegateThatThrows = (event, context) => {
 }
 ```
 
-Error message will be included in the response body in the "message"
-attribute. The response body contains also a direct link to CloudWatch Logs for
+The error message will be set to the "message" property of the response. 
+This can be customized by providing an **errorFormatter** function
+in the generator options.
+The response body contains also a direct link to CloudWatch Logs for
 this request. Returning the log link can be disabled by setting value **false**
 for key **cloudWatchLogLinks** in the generator options.
+
+```javascript
+const delegate = (event, context) => {
+  //
+}
+const options = {
+  cloudWatchLogLinks: false,
+  logErrors: true,
+  errorFormatter: (error) => error.message.substring(0, 20)
+}
+module.exports = {
+  handler: require('agw-lambda-proxy').createHandler(delegate, options)
+}
+```
 
 ## License
 

--- a/index.js
+++ b/index.js
@@ -74,6 +74,9 @@ const createHandler = (delegate, options = {}) => {
   if (typeof delegate !== 'function') {
     throw new Error('"delegate" must be a function')
   }
+  if (options.hasOwnProperty('errorFormatter') && typeof options.errorFormatter !== 'function') {
+    throw new Error('"errorFormatter" option must be a function')
+  }
   const combinedOptions = Object.assign({}, DEFAULT_OPTIONS, options)
   return (event, context, callback) => {
     return Promise.resolve()

--- a/index.js
+++ b/index.js
@@ -55,7 +55,7 @@ const requestErrorHandler = (context, options) => (error) => {
   return {
     statusCode: error.code || 500,
     body: {
-      message: error.message,
+      message: options.errorFormatter(error),
       log: options.cloudWatchLogLinks ? createLogLink(context) : undefined
     }
   }
@@ -66,7 +66,8 @@ const DEFAULT_OPTIONS = {
     'Access-Control-Allow-Origin': '*'
   },
   cloudWatchLogLinks: true,
-  logErrors: true
+  logErrors: true,
+  errorFormatter: (error) => error.message
 }
 
 const createHandler = (delegate, options = {}) => {

--- a/test/test.js
+++ b/test/test.js
@@ -218,5 +218,23 @@ describe('agw-lambda-proxy', function () {
           assert.deepEqual(response.headers, defaultHeaders, 'Default headers should be returned when response doesn\'t specify headers')
         })
     })
+
+    it('Should return customized error message', function () {
+      return asPromise(callback => createHandler(() => {
+        const er = new Error('should not be exposed')
+        return Promise.reject(er)
+      }, {
+        cloudWatchLogLinks: false,
+        logErrors: false,
+        errorFormatter: () => 'internal error'
+      })({}, context, callback))
+        .then((response) => {
+          assertResponseBody(response, {
+            message: 'internal error'
+          })
+          assert.equal(response.statusCode, 500, 'Default error status code should be 500')
+          assert.deepEqual(response.headers, defaultHeaders, 'Default headers should be returned when response doesn\'t specify headers')
+        })
+    })
   })
 })

--- a/test/test.js
+++ b/test/test.js
@@ -29,6 +29,11 @@ describe('agw-lambda-proxy', function () {
         createHandler(null)
       }, /"delegate" must be a function/)
     })
+    it('should throw when errorFormatter option is not a function', function () {
+      assert.throws(() => {
+        createHandler(() => 'x', {errorFormatter: '{0}'})
+      }, /"errorFormatter" option must be a function/)
+    })
     it('should return a function when parameters are valid', function () {
       assert(typeof createHandler(() => 'x') === 'function')
     })


### PR DESCRIPTION
Add a possibility to return customized error messages to the client.

The main motivation is that we don't want to expose error messages thrown by third party APIs (e.g. dynamodb client).